### PR TITLE
chore!: bump `webtoon` from 0.6.1 to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c66d1cd8ed61bf80b38432613a7a2f09401ab8d0501110655f8b341484a3e3"
+checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
@@ -401,9 +401,18 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.19"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -548,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "getopts"
-version = "0.2.21"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+checksum = "cba6ae63eb948698e300f645f87c70f76630d505f23b8907cf1e193ee85048c1"
 dependencies = [
  "unicode-width",
 ]
@@ -623,12 +632,11 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.29.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
+checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
 dependencies = [
  "log",
- "mac",
  "markup5ever",
  "match_token",
 ]
@@ -999,23 +1007,20 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markup5ever"
-version = "0.14.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
+checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
 dependencies = [
  "log",
- "phf",
- "phf_codegen",
- "string_cache",
- "string_cache_codegen",
  "tendril",
+ "web_atoms",
 ]
 
 [[package]]
 name = "match_token"
-version = "0.1.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1513,9 +1518,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scraper"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527e65d9d888567588db4c12da1087598d0f6f8b346cc2c5abc91f05fc2dffe2"
+checksum = "e5f3a24d916e78954af99281a455168d4a9515d65eca99a18da1b813689c4ad9"
 dependencies = [
  "cssparser",
  "ego-tree",
@@ -1528,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "scrapetoon"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1540,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.26.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
+checksum = "5685b6ae43bfcf7d2e7dfcfb5d8e8f61b46442c902531e41a32a9a8bf0ee0fb6"
 dependencies = [
  "bitflags 2.9.0",
  "cssparser",
@@ -1965,9 +1970,9 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "untrusted"
@@ -2138,6 +2143,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "web_atoms"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2148,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "webtoon"
-version = "0.6.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6c7d1f03a98f900ebeadea0a5eebf2ee74bc08d2e14d8a6f234665f29dfd7a"
+checksum = "cacb870c4a3387afc368547b906b2ace3555aaaa4f7eff27d4ac3d28a283ee95"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/RoloEdits/scrapetoon"
 [dependencies]
 clap = {version = "4", features = ["derive"]}
 tokio = { version = "1", features = ["full"] }
-webtoon = { version = "0.6.1", features = ["download"]}
+webtoon = "0.9.0"
 csv = "1"
 anyhow = { version = "1" }
 serde = {version = "1", features = ["derive"]}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <br/>
 
-`scrapetoon` is a commandline tool that offers a way to get a Webtoon's stats as well as the ability to download its episodes. Binaries are provided [here](https://github.com/RoloEdits/scrapetoon/releases).
+`scrapetoon` is a command-line tool that offers a way to get a Webtoon's stats as well as the ability to download its episodes. Binaries are provided [here](https://github.com/RoloEdits/scrapetoon/releases).
 
 Remember to always verify the data gathered before using!
 
@@ -53,8 +53,8 @@ scrapetoon download --url "https://www.webtoons.com/en/action/omniscient-reader/
 
 The data gathered from here is organized like so:
 
-| id  | creator | title | genre | views | subscribers | rating | episode | likes | comments | replies |
-| :-: | :-----: | :---: | :---: | :---: | :---------: | ------ | ------- | ----- | -------- | ------- |
+| id  | creator | title | genre | views | subscribers | episode | likes | comments | replies |
+| :-: | :-----: | :---: | :---: | :---: | :---------: | ------- | ----- | -------- | ------- |
 
 The `episode`, `likes`, `comments`, and `replies` are all relative to one episode, with a new episode on each row.
 
@@ -67,4 +67,4 @@ Example plots using the data:
 
 ## Download
 
-Downloaded episodes are downloaded as one big image and saved as a png. The title of the image corresponds to the episode number.
+Downloaded episodes are downloaded as one big image and saved as a PNG. The title of the image corresponds to the episode number.

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,6 @@ struct Stats<'a> {
     genre: &'a str,
     views: u64,
     subscribers: u32,
-    rating: f64,
     episode: u16,
     likes: u32,
     comments: u32,
@@ -57,7 +56,6 @@ async fn main() -> Result<()> {
                 .expect("At least one genre must exist");
             let subscribers = webtoon.subscribers().await?;
             let views = webtoon.views().await?;
-            let rating = webtoon.rating().await?;
 
             let episodes = args::parse_range_u16(&episodes)
                 .map_err(|err| anyhow!("failed to parse `{err}` as a valid episode number"))?;
@@ -82,7 +80,6 @@ async fn main() -> Result<()> {
                     genre,
                     views,
                     subscribers,
-                    rating,
                     episode: number,
                     likes,
                     comments,


### PR DESCRIPTION
BREAKING: `rating` is no longer a stat as it has been removed from the platform itself 